### PR TITLE
Open windows rewrites

### DIFF
--- a/modules/widgets/openwindowswidget/OpenWindowsScroller.qml
+++ b/modules/widgets/openwindowswidget/OpenWindowsScroller.qml
@@ -10,19 +10,15 @@ import qs.singletons
 ListView {
     id: windowScroller
     orientation: ListView.Horizontal
-    model: WindowManager.openWindows
+
+    model: WindowManager.windowKeys
     boundsBehavior: Flickable.StopAtBounds
     delegate: WindowButton {
-        property var modelData: [{
-            "id": id,
-            "title": title,
-            "minimized": minimized,
-            "addresses": addresses,
-            "iconPath": iconPath
-        }]
+        required property string modelData
+        property var windowInfo: WindowManager.openWindows[modelData]
     }
 
-    WindowPopupView {
-        id: windowPopup
-    }
+    // WindowPopupView {
+    //     id: windowPopup
+    // }
 }

--- a/modules/widgets/openwindowswidget/OpenWindowsScroller.qml
+++ b/modules/widgets/openwindowswidget/OpenWindowsScroller.qml
@@ -18,7 +18,8 @@ ListView {
         property var windowInfo: WindowManager.openWindows[modelData]
     }
 
-    // WindowPopupView {
-    //     id: windowPopup
-    // }
+    WindowPopupView {
+        id: windowPopup
+        anchor.item: windowScroller
+    }
 }

--- a/modules/widgets/openwindowswidget/OpenWindowsScroller.qml
+++ b/modules/widgets/openwindowswidget/OpenWindowsScroller.qml
@@ -7,22 +7,22 @@ import Quickshell.Hyprland
 import Quickshell.Wayland
 import qs.singletons
 
-//TODO: Figure out how to use scroll wheel for horizontal scrolling
-ScrollView {
+ListView {
     id: windowScroller
+    orientation: ListView.Horizontal
+    model: WindowManager.openWindows
+    boundsBehavior: Flickable.StopAtBounds
+    delegate: WindowButton {
+        property var modelData: [{
+            "id": id,
+            "title": title,
+            "minimized": minimized,
+            "addresses": addresses,
+            "iconPath": iconPath
+        }]
+    }
 
-    // ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-    ScrollBar.vertical.policy: ScrollBar.AlwaysOff
-
-    ScrollBar.horizontal.interactive: true
-    RowLayout {
-        Repeater {
-            model: ApplicationsManager.openWindows
-            delegate: WindowButton{
-                required property var modelData
-                windows: modelData
-                Layout.fillWidth: true
-            }
-        }
+    WindowPopupView {
+        id: windowPopup
     }
 }

--- a/modules/widgets/openwindowswidget/WindowButton.qml
+++ b/modules/widgets/openwindowswidget/WindowButton.qml
@@ -26,17 +26,31 @@ Button {
 
     onHoveredChanged: {
         if(button.hovered){
-            windowPopup.show(button)
+            showTimer.restart()
         }
         else{
+            hideTimer.restart()
+        }
+    }
+
+    Timer {
+        id: showTimer
+        interval: 200
+        onTriggered: {
+            hideTimer.stop()
+            windowPopup.show(button, windowInfo.addresses)
+        }
+    }
+
+    Timer {
+        id: hideTimer
+        interval: 10
+        onTriggered: {
+            showTimer.stop()
             windowPopup.hide()
         }
     }
 
     onClicked: {
-        var workspaceId = Hyprland.focusedWorkspace.id
-        var address = windowInfo.addresses.values().next().value
-        Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + address);
-        Hyprland.toplevels.values.find(w => w.address === address).wayland.activate()
     }
 }

--- a/modules/widgets/openwindowswidget/WindowButton.qml
+++ b/modules/widgets/openwindowswidget/WindowButton.qml
@@ -8,14 +8,13 @@ import qs.singletons
 
 Button {
     id: button
-    required property var windows
     property var minimized: false
 
     implicitWidth: windowScroller.height
     implicitHeight: windowScroller.height
 
     contentItem: Image{
-        source: windows[0].iconPath
+        source: modelData[0].iconPath
         sourceSize.width: button.width
         sourceSize.height: button.height
         fillMode: Image.PreserveAspectFit
@@ -26,7 +25,18 @@ Button {
         radius: 6
     }
 
-    WindowPopupView{
-        id: popup
+    onHoveredChanged: {
+        if(button.hovered){
+            windowPopup.showWindow(button)
+        }
+        else{
+            windowPopup.hideWindow()
+        }
+    }
+
+    onClicked: {
+        var workspaceId = Hyprland.focusedWorkspace.id
+        Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + model.addresses.addresses[0]);
+        Hyprland.toplevels.values.find(w => w.address === model.addresses.addresses[0]).wayland.activate()
     }
 }

--- a/modules/widgets/openwindowswidget/WindowButton.qml
+++ b/modules/widgets/openwindowswidget/WindowButton.qml
@@ -3,7 +3,6 @@ import QtQuick.Layouts
 import QtQuick.Controls
 import Quickshell
 import Quickshell.Hyprland
-import Quickshell.Wayland
 import qs.singletons
 
 Button {
@@ -14,7 +13,7 @@ Button {
     implicitHeight: windowScroller.height
 
     contentItem: Image{
-        source: modelData[0].iconPath
+        source: windowInfo.iconPath
         sourceSize.width: button.width
         sourceSize.height: button.height
         fillMode: Image.PreserveAspectFit
@@ -26,17 +25,18 @@ Button {
     }
 
     onHoveredChanged: {
-        if(button.hovered){
-            windowPopup.showWindow(button)
-        }
-        else{
-            windowPopup.hideWindow()
-        }
+        // if(button.hovered){
+        //     windowPopup.showWindow(button)
+        // }
+        // else{
+        //     windowPopup.hideWindow()
+        // }
     }
 
     onClicked: {
         var workspaceId = Hyprland.focusedWorkspace.id
-        Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + model.addresses.addresses[0]);
-        Hyprland.toplevels.values.find(w => w.address === model.addresses.addresses[0]).wayland.activate()
+        var address = windowInfo.addresses.values().next().value
+        Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + address);
+        Hyprland.toplevels.values.find(w => w.address === address).wayland.activate()
     }
 }

--- a/modules/widgets/openwindowswidget/WindowButton.qml
+++ b/modules/widgets/openwindowswidget/WindowButton.qml
@@ -25,12 +25,12 @@ Button {
     }
 
     onHoveredChanged: {
-        // if(button.hovered){
-        //     windowPopup.showWindow(button)
-        // }
-        // else{
-        //     windowPopup.hideWindow()
-        // }
+        if(button.hovered){
+            windowPopup.show(button)
+        }
+        else{
+            windowPopup.hide()
+        }
     }
 
     onClicked: {

--- a/modules/widgets/openwindowswidget/WindowPopupView.qml
+++ b/modules/widgets/openwindowswidget/WindowPopupView.qml
@@ -13,148 +13,176 @@ PopupWindow {
     implicitWidth: backgroundRec.width
     color: "transparent"
 
-    // These propertys handle hovering different elements in our popup window
-    //(NOTE: Probably a better way to do this but it's 1am and works so. Will come back to and refactor later.)
-    property bool closeButtonHovered: false
-    property bool singleWindowHovered: false
-
-    // Whether to open the window or not
-    property bool shouldShow: {
-        const hoverConditions = (closeButtonHovered || singleWindowHovered)
-        return hoverConditions
+    function show(anchorItem) {
+        anchor.item = anchorItem
+        showTimer.restart()
     }
 
-    onShouldShowChanged: {
-        updateTimer.restart()
+    function hide() {
+        visible = false
+        hideTimer.restart()
     }
 
-    // Timer to control updating the popup visibility after changing should show(Can change the time interval according to needs)
     Timer {
-        id: updateTimer
+        id: showTimer
         interval: 100
         onTriggered: {
-            popup.visible = popup.shouldShow
+            visible = true
         }
     }
+
+    Timer {
+        id: hideTimer
+        interval: 50
+        onTriggered: {
+            visible = false
+        }
+    }
+
+    // These propertys handle hovering different elements in our popup window
+    //(NOTE: Probably a better way to do this but it's 1am and works so. Will come back to and refactor later.)
+    // property bool closeButtonHovered: false
+    // property bool singleWindowHovered: false
+
+    // // Whether to open the window or not
+    // property bool shouldShow: {
+    //     const hoverConditions = (closeButtonHovered || singleWindowHovered)
+    //     return hoverConditions
+    // }
+
+    // onShouldShowChanged: {
+    //     updateTimer.restart()
+    // }
+
+    // // Timer to control updating the popup visibility after changing should show(Can change the time interval according to needs)
+    // Timer {
+    //     id: updateTimer
+    //     interval: 100
+    //     onTriggered: {
+    //         popup.visible = popup.shouldShow
+    //     }
+    // }
     
     // Popup window background
     Rectangle{
         id: backgroundRec
-        implicitHeight: previewRowLayout.implicitHeight
-        implicitWidth: previewRowLayout.implicitWidth 
+        // implicitHeight: previewRowLayout.implicitHeight
+        // implicitWidth: previewRowLayout.implicitWidth 
+        implicitHeight: 32
+        implicitWidth: 32
         color: Themes.primaryColor
         radius: 12
 
         // Row layout to hold all the windows associated with the application
-        RowLayout{
-            id: previewRowLayout
-            anchors.centerIn: parent
-            spacing: 10
+        // RowLayout{
+            // id: previewRowLayout
+            // anchors.centerIn: parent
+            // spacing: 10
 
             // Display all open windows in the popup
-             Repeater {
-                model: windows
-                delegate: Rectangle{
-                    id: delegateRoot
-                    required property var modelData
-                    property var padding: 15
-                    property var isHovered: false
-                    implicitWidth: columnLayout.implicitWidth + padding
-                    implicitHeight: columnLayout.implicitHeight + padding
-                    radius: 12
-                    color: isHovered ? Themes.primaryHoverColor : Themes.primaryColor
+            //  Repeater {
+            //     model: windows
+            //     delegate: Rectangle{
+            //         id: delegateRoot
+            //         required property var modelData
+            //         property var padding: 15
+            //         property var isHovered: false
+            //         implicitWidth: columnLayout.implicitWidth + padding
+            //         implicitHeight: columnLayout.implicitHeight + padding
+            //         radius: 12
+            //         color: isHovered ? Themes.primaryHoverColor : Themes.primaryColor
 
-                    ColumnLayout{
-                        id: columnLayout
-                        anchors.centerIn: parent
-                        implicitWidth: screenCopyView.width
+            //         ColumnLayout{
+            //             id: columnLayout
+            //             anchors.centerIn: parent
+            //             implicitWidth: screenCopyView.width
 
-                        RowLayout{
-                            Text{
-                                text: modelData.window.title
-                                color: Themes.textColor
-                                font.pixelSize: 12
-                                elide: Text.ElideRight 
-                                clip: true
-                                Layout.fillWidth: true
-                            }
-                            Button{
-                                id: closeWindowButton
-                                implicitHeight: 20
-                                implicitWidth: 20
-                                background: Rectangle {
-                                    color: closeWindowButton.hovered ? "red" : "transparent"
-                                    radius: 5
-                                }
-                                contentItem: Text{
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    text: "X"
-                                    color: Themes.textColor
-                                }
-                                Layout.alignment: Qt.AlignRight
-                                onClicked:{
-                                    // modelData.window.wayland.close()
-                                }
+            //             RowLayout{
+            //                 Text{
+            //                     text: modelData.window.title
+            //                     color: Themes.textColor
+            //                     font.pixelSize: 12
+            //                     elide: Text.ElideRight 
+            //                     clip: true
+            //                     Layout.fillWidth: true
+            //                 }
+            //                 Button{
+            //                     id: closeWindowButton
+            //                     implicitHeight: 20
+            //                     implicitWidth: 20
+            //                     background: Rectangle {
+            //                         color: closeWindowButton.hovered ? "red" : "transparent"
+            //                         radius: 5
+            //                     }
+            //                     contentItem: Text{
+            //                         horizontalAlignment: Text.AlignHCenter
+            //                         verticalAlignment: Text.AlignVCenter
+            //                         text: "X"
+            //                         color: Themes.textColor
+            //                     }
+            //                     Layout.alignment: Qt.AlignRight
+            //                     onClicked:{
+            //                         // modelData.window.wayland.close()
+            //                     }
 
-                                // Need this to make sure the window stays open even if we hover the child button
-                                onHoveredChanged: {
-                                    if(closeWindowButton.hovered){
-                                        closeButtonHovered = true
-                                    }
-                                    else{
-                                        closeButtonHovered = false
-                                    }
-                                }
-                            }
-                        }
-                        WindowPreview {
-                            id: screenCopyView
-                            waylandWindow: modelData.window.wayland
-                        }
-                    }
-                    MouseArea {
-                        id: singleWindowArea
-                        anchors.fill: parent
-                        hoverEnabled: true
-                        z: -1
+            //                     // Need this to make sure the window stays open even if we hover the child button
+            //                     onHoveredChanged: {
+            //                         if(closeWindowButton.hovered){
+            //                             closeButtonHovered = true
+            //                         }
+            //                         else{
+            //                             closeButtonHovered = false
+            //                         }
+            //                     }
+            //                 }
+            //             }
+            //             WindowPreview {
+            //                 id: screenCopyView
+            //                 waylandWindow: modelData.window.wayland
+            //             }
+            //         }
+            //         MouseArea {
+            //             id: singleWindowArea
+            //             anchors.fill: parent
+            //             hoverEnabled: true
+            //             z: -1
                         
-                        onClicked: {
-                            // if(modelData.minimized){
-                            //      var workspaceId = Hyprland.focusedWorkspace.id
+            //             onClicked: {
+            //                 // if(modelData.minimized){
+            //                 //      var workspaceId = Hyprland.focusedWorkspace.id
 
-                            //     // We fullscreen temporarily here to fix a weird bug with hyprland where swapping workspaces while another window is fullscreend cause the sub window to turn invisible
-                            //     // Recreate -> open two windows in the same workspace, fullscreen one to hide the other then change the workspace of the hidden window and it will turn invisible. 
-                            //     // Toggling fullscreen forces a redraw because hyprland doesnt have a redraw command exposed.
-                            //     // (May be fixed in future hyprland releases will check back on this)
-                            //     modelData.window.wayland.fullscreen = true
-                            //     modelData.window.wayland.fullscreen = false
-                            //     //*****************************************************************************/
+            //                 //     // We fullscreen temporarily here to fix a weird bug with hyprland where swapping workspaces while another window is fullscreend cause the sub window to turn invisible
+            //                 //     // Recreate -> open two windows in the same workspace, fullscreen one to hide the other then change the workspace of the hidden window and it will turn invisible. 
+            //                 //     // Toggling fullscreen forces a redraw because hyprland doesnt have a redraw command exposed.
+            //                 //     // (May be fixed in future hyprland releases will check back on this)
+            //                 //     modelData.window.wayland.fullscreen = true
+            //                 //     modelData.window.wayland.fullscreen = false
+            //                 //     //*****************************************************************************/
 
-                            //     Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + modelData.window.address);
-                            //     modelData.minimized = false
-                            //     modelData.window.wayland.activate()
-                            // }
-                            // else{
-                            //     // Wont move mouse cursor and focus if window is already focused by hyprland
-                            //     modelData.window.wayland.activate()
-                            //     singleWindowHovered = false
-                            // }
-                        }
+            //                 //     Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + modelData.window.address);
+            //                 //     modelData.minimized = false
+            //                 //     modelData.window.wayland.activate()
+            //                 // }
+            //                 // else{
+            //                 //     // Wont move mouse cursor and focus if window is already focused by hyprland
+            //                 //     modelData.window.wayland.activate()
+            //                 //     singleWindowHovered = false
+            //                 // }
+            //             }
 
-                        onContainsMouseChanged: {
-                            if(singleWindowArea.containsMouse){
-                                singleWindowHovered = true
-                                isHovered = true
-                            }
-                            else{
-                                singleWindowHovered = false
-                                isHovered = false
-                            }
-                        }
-                    }
-                }
-            }
-        }
+            //             onContainsMouseChanged: {
+            //                 if(singleWindowArea.containsMouse){
+            //                     singleWindowHovered = true
+            //                     isHovered = true
+            //                 }
+            //                 else{
+            //                     singleWindowHovered = false
+            //                     isHovered = false
+            //                 }
+            //             }
+            //         }
+            //     }
+            // }
+        // }
     }
 }

--- a/modules/widgets/openwindowswidget/WindowPopupView.qml
+++ b/modules/widgets/openwindowswidget/WindowPopupView.qml
@@ -8,181 +8,171 @@ import Quickshell.Hyprland
 import qs.singletons
 
 PopupWindow {
+    id: mainPopup
+    property var buttonHovered: false
+    property var addresses: []
     anchor.rect.y: -height - 20
     implicitHeight: backgroundRec.height
     implicitWidth: backgroundRec.width
     color: "transparent"
 
-    function show(anchorItem) {
+    function show(anchorItem, windowAddresses) {
         anchor.item = anchorItem
-        showTimer.restart()
+        buttonHovered = true
+        addresses = windowAddresses
+        updateVisibility()
     }
 
     function hide() {
-        visible = false
-        hideTimer.restart()
+        buttonHovered = false
+        updateVisibility()
     }
 
-    Timer {
-        id: showTimer
-        interval: 100
-        onTriggered: {
+    function updateVisibility() {
+        if(buttonHovered || baseHover.hovered)
+        {
+            hideTimer.stop()
             visible = true
+        }
+        else {
+            hideTimer.restart()
         }
     }
 
     Timer {
         id: hideTimer
-        interval: 50
+        interval: 100
         onTriggered: {
             visible = false
         }
     }
-
-    // These propertys handle hovering different elements in our popup window
-    //(NOTE: Probably a better way to do this but it's 1am and works so. Will come back to and refactor later.)
-    // property bool closeButtonHovered: false
-    // property bool singleWindowHovered: false
-
-    // // Whether to open the window or not
-    // property bool shouldShow: {
-    //     const hoverConditions = (closeButtonHovered || singleWindowHovered)
-    //     return hoverConditions
-    // }
-
-    // onShouldShowChanged: {
-    //     updateTimer.restart()
-    // }
-
-    // // Timer to control updating the popup visibility after changing should show(Can change the time interval according to needs)
-    // Timer {
-    //     id: updateTimer
-    //     interval: 100
-    //     onTriggered: {
-    //         popup.visible = popup.shouldShow
-    //     }
-    // }
     
     // Popup window background
     Rectangle{
         id: backgroundRec
-        // implicitHeight: previewRowLayout.implicitHeight
-        // implicitWidth: previewRowLayout.implicitWidth 
-        implicitHeight: 32
-        implicitWidth: 32
+        implicitHeight: previewRowLayout.implicitHeight
+        implicitWidth: previewRowLayout.implicitWidth 
         color: Themes.primaryColor
         radius: 12
 
         // Row layout to hold all the windows associated with the application
-        // RowLayout{
-            // id: previewRowLayout
-            // anchors.centerIn: parent
-            // spacing: 10
+        RowLayout{
+            id: previewRowLayout
+            anchors.centerIn: parent
+            anchors.fill: parent
+            spacing: 10
 
             // Display all open windows in the popup
-            //  Repeater {
-            //     model: windows
-            //     delegate: Rectangle{
-            //         id: delegateRoot
-            //         required property var modelData
-            //         property var padding: 15
-            //         property var isHovered: false
-            //         implicitWidth: columnLayout.implicitWidth + padding
-            //         implicitHeight: columnLayout.implicitHeight + padding
-            //         radius: 12
-            //         color: isHovered ? Themes.primaryHoverColor : Themes.primaryColor
+             Repeater {
+                model: addresses
+                delegate: Rectangle{
+                    id: delegateRoot
+                    required property var modelData
+                    property var window: Hyprland.toplevels.values.find(w => w.address == modelData)
+                    property var padding: 15
+                    property var isHovered: false
+                    implicitWidth: columnLayout.implicitWidth + padding
+                    implicitHeight: columnLayout.implicitHeight + padding
+                    radius: 12
+                    color: isHovered ? Themes.primaryHoverColor : Themes.primaryColor
 
-            //         ColumnLayout{
-            //             id: columnLayout
-            //             anchors.centerIn: parent
-            //             implicitWidth: screenCopyView.width
+                    ColumnLayout{
+                        id: columnLayout
+                        anchors.centerIn: parent
+                        implicitWidth: screenCopyLoader.item ? screenCopyLoader.item.width : 100
 
-            //             RowLayout{
-            //                 Text{
-            //                     text: modelData.window.title
-            //                     color: Themes.textColor
-            //                     font.pixelSize: 12
-            //                     elide: Text.ElideRight 
-            //                     clip: true
-            //                     Layout.fillWidth: true
-            //                 }
-            //                 Button{
-            //                     id: closeWindowButton
-            //                     implicitHeight: 20
-            //                     implicitWidth: 20
-            //                     background: Rectangle {
-            //                         color: closeWindowButton.hovered ? "red" : "transparent"
-            //                         radius: 5
-            //                     }
-            //                     contentItem: Text{
-            //                         horizontalAlignment: Text.AlignHCenter
-            //                         verticalAlignment: Text.AlignVCenter
-            //                         text: "X"
-            //                         color: Themes.textColor
-            //                     }
-            //                     Layout.alignment: Qt.AlignRight
-            //                     onClicked:{
-            //                         // modelData.window.wayland.close()
-            //                     }
-
-            //                     // Need this to make sure the window stays open even if we hover the child button
-            //                     onHoveredChanged: {
-            //                         if(closeWindowButton.hovered){
-            //                             closeButtonHovered = true
-            //                         }
-            //                         else{
-            //                             closeButtonHovered = false
-            //                         }
-            //                     }
-            //                 }
-            //             }
-            //             WindowPreview {
-            //                 id: screenCopyView
-            //                 waylandWindow: modelData.window.wayland
-            //             }
-            //         }
-            //         MouseArea {
-            //             id: singleWindowArea
-            //             anchors.fill: parent
-            //             hoverEnabled: true
-            //             z: -1
+                        RowLayout{
+                            Text{
+                                text: window ? window.title : ""
+                                color: Themes.textColor
+                                font.pixelSize: 12
+                                elide: Text.ElideRight 
+                                clip: true
+                                Layout.fillWidth: true
+                            }
+                            Button{
+                                id: closeWindowButton
+                                implicitHeight: 20
+                                implicitWidth: 20
+                                background: Rectangle {
+                                    color: closeWindowButton.hovered ? "red" : "transparent"
+                                    radius: 5
+                                }
+                                contentItem: Text{
+                                    horizontalAlignment: Text.AlignHCenter
+                                    verticalAlignment: Text.AlignVCenter
+                                    text: "X"
+                                    color: Themes.textColor
+                                }
+                                Layout.alignment: Qt.AlignRight
+                                onClicked:{
+                                    if(window){
+                                        if(addresses.length <= 1){
+                                            mainPopup.visible = false
+                                            window.wayland.close()
+                                        }
+                                        else{
+                                            window.wayland.close()
+                                            addresses = addresses.filter(add => add !== window.address)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Loader {
+                            id: screenCopyLoader
+                            active: (window !== undefined) && window.wayland
+                            sourceComponent: WindowPreview {
+                                waylandWindow: window.wayland
+                            }
+                        }
+                    }
+                    MouseArea {
+                        id: singleWindowArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        z: -1
                         
-            //             onClicked: {
-            //                 // if(modelData.minimized){
-            //                 //      var workspaceId = Hyprland.focusedWorkspace.id
+                        onClicked: {
+                            if(window.workspace.id == -99){
+                                 var workspaceId = Hyprland.focusedWorkspace.id
 
-            //                 //     // We fullscreen temporarily here to fix a weird bug with hyprland where swapping workspaces while another window is fullscreend cause the sub window to turn invisible
-            //                 //     // Recreate -> open two windows in the same workspace, fullscreen one to hide the other then change the workspace of the hidden window and it will turn invisible. 
-            //                 //     // Toggling fullscreen forces a redraw because hyprland doesnt have a redraw command exposed.
-            //                 //     // (May be fixed in future hyprland releases will check back on this)
-            //                 //     modelData.window.wayland.fullscreen = true
-            //                 //     modelData.window.wayland.fullscreen = false
-            //                 //     //*****************************************************************************/
+                                // We fullscreen temporarily here to fix a weird bug with hyprland where swapping workspaces while another window is fullscreend cause the sub window to turn invisible
+                                // Recreate -> open two windows in the same workspace, fullscreen one to hide the other then change the workspace of the hidden window and it will turn invisible. 
+                                // Toggling fullscreen forces a redraw because hyprland doesnt have a redraw command exposed.
+                                // (May be fixed in future hyprland releases will check back on this)
+                                window.wayland.fullscreen = true
+                                window.wayland.fullscreen = false
+                                //*****************************************************************************/
 
-            //                 //     Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + modelData.window.address);
-            //                 //     modelData.minimized = false
-            //                 //     modelData.window.wayland.activate()
-            //                 // }
-            //                 // else{
-            //                 //     // Wont move mouse cursor and focus if window is already focused by hyprland
-            //                 //     modelData.window.wayland.activate()
-            //                 //     singleWindowHovered = false
-            //                 // }
-            //             }
+                                Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + window.address);
+                                window.wayland.activate()
+                            }
+                            else{
+                                // Wont move mouse cursor and focus if window is already focused by hyprland
+                                window.wayland.activate()
+                            }
+                        }
 
-            //             onContainsMouseChanged: {
-            //                 if(singleWindowArea.containsMouse){
-            //                     singleWindowHovered = true
-            //                     isHovered = true
-            //                 }
-            //                 else{
-            //                     singleWindowHovered = false
-            //                     isHovered = false
-            //                 }
-            //             }
-            //         }
-            //     }
-            // }
-        // }
+                        onContainsMouseChanged: {
+                            if(singleWindowArea.containsMouse){
+                                isHovered = true
+                            }
+                            else{
+                                isHovered = false
+                            }
+                        }
+                    }
+                }
+            }
+
+            HoverHandler {
+                id: baseHover
+
+                onHoveredChanged: {
+                    updateVisibility()
+                }
+            }
+        }
     }
 }

--- a/modules/widgets/openwindowswidget/WindowPopupView.qml
+++ b/modules/widgets/openwindowswidget/WindowPopupView.qml
@@ -58,8 +58,6 @@ PopupWindow {
         // Row layout to hold all the windows associated with the application
         RowLayout{
             id: previewRowLayout
-            anchors.centerIn: parent
-            anchors.fill: parent
             spacing: 10
 
             // Display all open windows in the popup

--- a/modules/widgets/openwindowswidget/WindowPopupView.qml
+++ b/modules/widgets/openwindowswidget/WindowPopupView.qml
@@ -8,7 +8,6 @@ import Quickshell.Hyprland
 import qs.singletons
 
 PopupWindow {
-    anchor.item: button
     anchor.rect.y: -height - 20
     implicitHeight: backgroundRec.height
     implicitWidth: backgroundRec.width
@@ -21,7 +20,7 @@ PopupWindow {
 
     // Whether to open the window or not
     property bool shouldShow: {
-        const hoverConditions = (button.hovered || closeButtonHovered || singleWindowHovered)
+        const hoverConditions = (closeButtonHovered || singleWindowHovered)
         return hoverConditions
     }
 
@@ -95,7 +94,7 @@ PopupWindow {
                                 }
                                 Layout.alignment: Qt.AlignRight
                                 onClicked:{
-                                    modelData.window.wayland.close()
+                                    // modelData.window.wayland.close()
                                 }
 
                                 // Need this to make sure the window stays open even if we hover the child button
@@ -121,26 +120,26 @@ PopupWindow {
                         z: -1
                         
                         onClicked: {
-                            if(modelData.minimized){
-                                 var workspaceId = Hyprland.focusedWorkspace.id
+                            // if(modelData.minimized){
+                            //      var workspaceId = Hyprland.focusedWorkspace.id
 
-                                // We fullscreen temporarily here to fix a weird bug with hyprland where swapping workspaces while another window is fullscreend cause the sub window to turn invisible
-                                // Recreate -> open two windows in the same workspace, fullscreen one to hide the other then change the workspace of the hidden window and it will turn invisible. 
-                                // Toggling fullscreen forces a redraw because hyprland doesnt have a redraw command exposed.
-                                // (May be fixed in future hyprland releases will check back on this)
-                                modelData.window.wayland.fullscreen = true
-                                modelData.window.wayland.fullscreen = false
-                                //*****************************************************************************/
+                            //     // We fullscreen temporarily here to fix a weird bug with hyprland where swapping workspaces while another window is fullscreend cause the sub window to turn invisible
+                            //     // Recreate -> open two windows in the same workspace, fullscreen one to hide the other then change the workspace of the hidden window and it will turn invisible. 
+                            //     // Toggling fullscreen forces a redraw because hyprland doesnt have a redraw command exposed.
+                            //     // (May be fixed in future hyprland releases will check back on this)
+                            //     modelData.window.wayland.fullscreen = true
+                            //     modelData.window.wayland.fullscreen = false
+                            //     //*****************************************************************************/
 
-                                Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + modelData.window.address);
-                                modelData.minimized = false
-                                modelData.window.wayland.activate()
-                            }
-                            else{
-                                // Wont move mouse cursor and focus if window is already focused by hyprland
-                                modelData.window.wayland.activate()
-                                singleWindowHovered = false
-                            }
+                            //     Hyprland.dispatch("movetoworkspacesilent " + workspaceId + ", address:0x" + modelData.window.address);
+                            //     modelData.minimized = false
+                            //     modelData.window.wayland.activate()
+                            // }
+                            // else{
+                            //     // Wont move mouse cursor and focus if window is already focused by hyprland
+                            //     modelData.window.wayland.activate()
+                            //     singleWindowHovered = false
+                            // }
                         }
 
                         onContainsMouseChanged: {

--- a/singletons/ApplicationsManager.qml
+++ b/singletons/ApplicationsManager.qml
@@ -8,10 +8,10 @@ Singleton {
     id: root
 
     property var entries: []
-    property var rawWindows: Hyprland.toplevels.values
-    property var openWindows: createOpenWindows()
     
-    Component.onCompleted: updateEntries()
+    Component.onCompleted: {
+        updateEntries()
+    }
     
     Connections {
         target: DesktopEntries.applications
@@ -42,89 +42,5 @@ Singleton {
         }
 
         entries = apps.sort((a, b) => a.name.localeCompare(b.name))
-    }
-
-    // Create custom window dict to return(We use function to keep binding to Hyprland toplevel values)
-    function createOpenWindows(){
-        var dict = {}
-
-        rawWindows.filter(w => w.wayland).forEach(w => {
-            var appId = w.wayland.appId
-            var application = DesktopEntries.heuristicLookup(appId)
-
-            // Check if we found something with the heuristic look up and if not check if its  chrome webapp
-            if(!application){
-                if(appId.includes("chrome")){
-                    application = DesktopEntries.heuristicLookup("chromium")
-                }
-            }
-            
-            // We attempt to get the icon path here as not all appIds corrospond to applicaitons, so we want to make sure some icon is displayed
-            var iconPath = ""
-            if(application){
-                iconPath = Quickshell.iconPath(application.icon, true)
-            }
-            else {
-                iconPath = Quickshell.iconPath(appId, true)
-            }
-
-            if(iconPath == ""){
-                if(appId.includes("steam")){
-                    iconPath = Quickshell.iconPath(appId.replace("app", "icon"), true)
-                }
-                
-                if(iconPath == ""){
-                    iconPath = Quickshell.iconPath(findIconFallback(appId), true)
-                }
-
-                if(iconPath == ""){
-                    iconPath = Quickshell.iconPath("application-default-icon", true)
-                }
-            }
-
-            var minimized = false
-
-                if(!dict[appId]) {
-                dict[appId] = []
-            }
-
-            if(w.workspace){
-                if(w.workspace.id == -99){
-                    minimized = true
-                }
-            }
-            dict[appId].push({
-                id: appId, // The wayland app id of the window
-                minimized: minimized, // Whether the window is minimized or not(Meaning if it is in the special workspace or not)
-                window: w, // The quickshell hyprland toplevel object
-                application: application, // The application associated with this window if any
-                iconPath: iconPath // The icon path for the window
-            })
-            
-        })
-
-        return Object.values(dict)
-    }
-
-    function findIconFallback(appId){
-        // 2. Convert to lowercase for case-insensitive matching
-        let searchId = appId.toLowerCase();
-        
-        // 3. Remove version numbers and common suffixes
-        // Match patterns like "1.21.1", "v2.0", etc.
-        searchId = searchId.replace(/[_\s-]*(v?\d+\.)*\d+(\.\d+)*[_\s-]*/g, '');
-        
-        // 4. Remove common special characters and cleanup
-        searchId = searchId.replace(/[*&$@#!()[\]{}]/g, '');
-        
-        // 5. Remove common suffixes
-        searchId = searchId.replace(/[_\s-]*(beta|alpha|stable|dev|nightly|git)$/i, '');
-        
-        // 6. Split on common separators and take first significant part
-        let parts = searchId.split(/[_\s-]+/);
-        searchId = parts[0] || searchId;
-        
-        // 7. Try to find icon with this cleaned name
-        return searchId;
     }
 }

--- a/singletons/WindowManager.qml
+++ b/singletons/WindowManager.qml
@@ -36,7 +36,7 @@ Singleton {
 
         // Refresh addresses
         Object.keys(openWindows).forEach(appId => {
-            openWindows[appId].addresses = new Set()
+            openWindows[appId].addresses = []
         })
 
         Hyprland.toplevels.values.filter(w => w.wayland).forEach(w => {
@@ -57,14 +57,14 @@ Singleton {
             if(!openWindows[appId]){
                 openWindows[appId] = {
                     id: String(appId), // The wayland app id of the window
-                    addresses: new Set(),
+                    addresses: [],
                     iconPath: String(iconPath) // The icon path for the window
                 }
 
-                openWindows[appId].addresses.add(w.address)
+                openWindows[appId].addresses.push(w.address)
             }
             else {
-                openWindows[appId].addresses.add(w.address)
+                openWindows[appId].addresses.push(w.address)
             }
         })
 

--- a/singletons/WindowManager.qml
+++ b/singletons/WindowManager.qml
@@ -57,10 +57,7 @@ Singleton {
             if(!openWindows[appId]){
                 openWindows[appId] = {
                     id: String(appId), // The wayland app id of the window
-                    title: String(w.title),
-                    minimized: Boolean((w.workspace.id == -99)),
                     addresses: new Set(),
-                    // application: application, // The application associated with this window if any
                     iconPath: String(iconPath) // The icon path for the window
                 }
 

--- a/singletons/WindowManager.qml
+++ b/singletons/WindowManager.qml
@@ -1,0 +1,118 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Hyprland
+
+Singleton {
+    id: root
+
+    property ListModel openWindows: ListModel {}
+    
+    Component.onCompleted: {
+        updateTimer.restart()
+    }
+
+    Connections {
+        target: Hyprland.toplevels
+        function onValuesChanged() {
+            updateTimer.restart()
+        }
+    }
+
+    Timer {
+        id: updateTimer
+        interval: 1000
+        onTriggered: {
+            updateOpenWindows()
+        }
+    }
+
+    // Create custom window dict to return(We use function to keep binding to Hyprland toplevel values)
+    function updateOpenWindows(){
+        openWindows.clear()
+        var groupedWindows = {}
+
+        Hyprland.toplevels.values.filter(w => w.wayland).forEach(w => {
+            var appId = w.wayland.appId
+            var application = DesktopEntries.heuristicLookup(appId)
+
+            // Check if we found something with the heuristic look up and if not check if its  chrome webapp
+            if(!application){
+                if(appId.includes("chrome")){
+                    application = DesktopEntries.heuristicLookup("chromium")
+                }
+            }
+            
+            // We attempt to get the icon path here as not all appIds corrospond to applicaitons, so we want to make sure some icon is displayed
+            var iconPath = getIcon(appId, application)
+
+            if(!groupedWindows[appId]){
+                groupedWindows[appId] = {
+                    id: String(appId), // The wayland app id of the window
+                    title: String(w.title),
+                    minimized: Boolean((w.workspace.id == -99)),
+                    addresses: {addresses: [w.address]},
+                    // application: application, // The application associated with this window if any
+                    iconPath: String(iconPath) // The icon path for the window
+                }
+                
+            }
+            else {
+                groupedWindows.addresses.addresses.push(w.address)
+            }
+        })
+
+        Object.values(groupedWindows).forEach(win => {
+            openWindows.append(win)  // Arrays get converted here, but we're done modifying
+        })
+    }
+
+    function getIcon(appId, application) {
+        var iconPath = ""
+        if(application){
+            iconPath = Quickshell.iconPath(application.icon, true)
+        }
+        else {
+            iconPath = Quickshell.iconPath(appId, true)
+        }
+
+        if(iconPath == ""){
+            if(appId.includes("steam")){
+                iconPath = Quickshell.iconPath(appId.replace("app", "icon"), true)
+            }
+            
+            if(iconPath == ""){
+                iconPath = Quickshell.iconPath(findIconFallback(appId), true)
+            }
+
+            if(iconPath == ""){
+                iconPath = Quickshell.iconPath("application-default-icon", true)
+            }
+        }
+
+        return iconPath
+    }
+
+    function findIconFallback(appId){
+        // 2. Convert to lowercase for case-insensitive matching
+        let searchId = appId.toLowerCase();
+        
+        // 3. Remove version numbers and common suffixes
+        // Match patterns like "1.21.1", "v2.0", etc.
+        searchId = searchId.replace(/[_\s-]*(v?\d+\.)*\d+(\.\d+)*[_\s-]*/g, '');
+        
+        // 4. Remove common special characters and cleanup
+        searchId = searchId.replace(/[*&$@#!()[\]{}]/g, '');
+        
+        // 5. Remove common suffixes
+        searchId = searchId.replace(/[_\s-]*(beta|alpha|stable|dev|nightly|git)$/i, '');
+        
+        // 6. Split on common separators and take first significant part
+        let parts = searchId.split(/[_\s-]+/);
+        searchId = parts[0] || searchId;
+        
+        // 7. Try to find icon with this cleaned name
+        return searchId;
+    }
+}


### PR DESCRIPTION
Full refactor of how getting and storing hyprland windows works for the taskbar icons list. Moved the popupwindow for the taskbar applications to a singular popupwindow that they all share instead of constantly destroying and creating new windows. Helps with performance and squashes a rendering error.